### PR TITLE
Fix convert args index error in Perfetto

### DIFF
--- a/xtc
+++ b/xtc
@@ -395,6 +395,24 @@ EOF;
             //TODO: visualize vars assignments mb using $lastFunctionIndex somehow draw them on timeline or in separate frame
             //if ($recordType === static::RECORD_ASSIGMENT && isset($events[$lastFunctionIndex])) {}
         }
+
+        /**
+         * In perfetto web ui, args must be an object, it should not be an array, so if there are no parameters when the
+         * method is called or xdebug.collect_params is not set, an error will be raised when using perfetto web ui.
+         * UI: https://ui.perfetto.dev/v48.1-eb5adbbd8
+         *
+         * Failure parsing JSON: unsupported JSON dictionary with array: '[],"dur":50903209}'
+         *
+         * Trace: not available (No trace loaded). Provide repro steps.
+         *
+         * @see https://ui.perfetto.dev/
+         */
+        foreach ($events as $eventIndex => $event) {
+            if (empty($event['args']) && is_array($event['args'])) {
+                $events[$eventIndex]['args'] = (object) $event['args'];
+            }
+        }
+
         if (empty($events)) {
             echo PHP_EOL;
             echo '-> Trace file is empty or malformed.' . PHP_EOL;


### PR DESCRIPTION
In Perfetto web ui, args must be an object, it should not be an array, so if there are no parameters when the method is called or xdebug.collect_params is not set, an error will be raised when using Perfetto web ui.

```text
Failure parsing JSON: unsupported JSON dictionary with array: '[],"dur":50903209}'

Trace: not available (No trace loaded). Provide repro steps.
```

See: https://ui.perfetto.dev/

Note: Chromium Trace Event Format There is no detailed description of the types of args parameters (array or object?). But according to their example, this should be an object

See: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?pli=1&tab=t.0

---

The idea of ​​this converter is very good. Before this, I couldn't find a suitable tool to view xdebug trace files on Windows, although there are already good tools for viewing on Mac and Linux.

Before this, I tried to use an xdebug-trace-viewer, which is a tool developed based on electron, but it will be very stuck when processing large files, and it will also crash strangely and fail to load. And for Laravel, after passing through many middlewares, the tree view calls will be very deeply nested, which is very troublesome to retrieve, so I have been looking for a replacement. I saw this tool in the comments section of Jetbrains PHPSTORM Blog and felt it was very interesting.

When I tried to convert a 1.2GiB trace file to about 750MiB (xdebug.collect_params = 4), an error occurred when loading it in Performance in Chrome Devtools.

```
Malformed timeline data: SyntaxError: Unexpected end of JSON input
```

I thought the JSON file was too large, because it can handle 200MiB JSON files in the same way without any problems.

When I tried to use jsonlint to validate the 750MiB JSON file, I got an error

```text
Error: Cannot create a string longer than 0x1fffffe8 characters
```

So, I thought Chromium should have encountered a similar problem. Then I found Perfetto, which can load successfully and display with almost no lag.

But I found that Perfetto will generate a parsing error in the method call with args as an empty array, so I sent this PR.

However, I can’t see the args in my Chrome Devtools Summary, while Perfetto does.